### PR TITLE
Allow overriding the dotnet exe

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
   nupkg-dir:
     description: 'Directory in which to find the NuGet .nupkg file'
     required: true
+  dotnet:
+    description: 'Path to the `dotnet` executable.'
+    required: false
+    default: 'dotnet'
 
 runs:
   using: "composite"
@@ -23,6 +27,7 @@ runs:
         NUGET_API_KEY: ${{ inputs.nuget-key }}
         PACKAGE_DIR: ${{ inputs.nupkg-dir }}
         PACKAGE_NAME: ${{ inputs.package-name }}
+        DOTNET_EXE: ${{ inputs.dotnet }}
       run: '$GITHUB_ACTION_PATH/nuget_push.sh "$PACKAGE_DIR"/"$PACKAGE_NAME".*.nupkg'
     - name: Wait for availability
       shell: bash

--- a/nuget_push.sh
+++ b/nuget_push.sh
@@ -12,7 +12,7 @@ echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
 
 tmp=$(mktemp)
 
-if ! dotnet nuget push "$SOURCE_NUPKG" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE" > "$tmp" ; then
+if ! "$DOTNET_EXE" nuget push "$SOURCE_NUPKG" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE" > "$tmp" ; then
     cat "$tmp"
     if grep 'already exists and cannot be modified' "$tmp" ; then
         echo "result=skipped" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This is so that I can pull the `dotnet` out of my `nix develop` devshell.